### PR TITLE
Added option allowing compilation of both static and dynamic library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ if(PAGMO_BUILD_PAGMO)
     endif()
 
     # Setup of the pagmo library.
-    add_library(pagmo SHARED "${PAGMO_SRC_FILES}")
+    add_library(pagmo STATIC "${PAGMO_SRC_FILES}")
     set_property(TARGET pagmo PROPERTY VERSION "1.0")
     set_property(TARGET pagmo PROPERTY SOVERSION 1)
     target_compile_options(pagmo PRIVATE "$<$<CONFIG:DEBUG>:${PAGMO_CXX_FLAGS_DEBUG}>" "$<$<CONFIG:RELEASE>:${PAGMO_CXX_FLAGS_RELEASE}>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,12 @@ if(PAGMO_BUILD_PAGMO)
     endif()
 
     # Setup of the pagmo library.
-    add_library(pagmo STATIC "${PAGMO_SRC_FILES}")
+    if(PAGMO_AS_STATIC_LIB)
+        add_library(pagmo STATIC "${PAGMO_SRC_FILES}")
+    else()
+        add_library(pagmo SHARED "${PAGMO_SRC_FILES}")
+    endif()
+
     set_property(TARGET pagmo PROPERTY VERSION "1.0")
     set_property(TARGET pagmo PROPERTY SOVERSION 1)
     target_compile_options(pagmo PRIVATE "$<$<CONFIG:DEBUG>:${PAGMO_CXX_FLAGS_DEBUG}>" "$<$<CONFIG:RELEASE>:${PAGMO_CXX_FLAGS_RELEASE}>")

--- a/include/pagmo/detail/visibility.hpp
+++ b/include/pagmo/detail/visibility.hpp
@@ -38,15 +38,21 @@ see https://www.gnu.org/licenses/. */
 // empty.
 #if defined(_WIN32) || defined(__CYGWIN__)
 
-#define pagmo_EXPORTS
-
 #if defined(pagmo_EXPORTS)
 
 #define PAGMO_DLL_PUBLIC __declspec(dllexport)
 
 #else
 
+#if defined(PAGMO_STATIC_LIB)
+
+#define PAGMO_DLL_PUBLIC
+
+#else
+
 #define PAGMO_DLL_PUBLIC __declspec(dllimport)
+
+#endif
 
 #endif
 

--- a/include/pagmo/detail/visibility.hpp
+++ b/include/pagmo/detail/visibility.hpp
@@ -38,6 +38,8 @@ see https://www.gnu.org/licenses/. */
 // empty.
 #if defined(_WIN32) || defined(__CYGWIN__)
 
+#define pagmo_EXPORTS
+
 #if defined(pagmo_EXPORTS)
 
 #define PAGMO_DLL_PUBLIC __declspec(dllexport)


### PR DESCRIPTION
Added code to give users the option to compile Pagmo 2 into a static or dynamic link library, by reading a CMake cache option and using it to alter dllimport/dllexport decorations (as required by compilation on Windows).